### PR TITLE
Correct JsonReaderException: JSON integer is too large for an Int32

### DIFF
--- a/build/docs/TranscriptionTopicTranscriptionMessage.md
+++ b/build/docs/TranscriptionTopicTranscriptionMessage.md
@@ -11,8 +11,8 @@ title: TranscriptionTopicTranscriptionMessage
 | **OrganizationId** | **string** |  | [optional] |
 | **ConversationId** | **string** |  | [optional] |
 | **CommunicationId** | **string** |  | [optional] |
-| **SessionStartTimeMs** | **int?** |  | [optional] |
-| **TranscriptionStartTimeMs** | **int?** |  | [optional] |
+| **SessionStartTimeMs** | **long?** |  | [optional] |
+| **TranscriptionStartTimeMs** | **long?** |  | [optional] |
 | **Transcripts** | [**List&lt;TranscriptionTopicTranscriptResult&gt;**](TranscriptionTopicTranscriptResult.html) |  | [optional] |
 | **Status** | [**TranscriptionTopicTranscriptionRequestStatus**](TranscriptionTopicTranscriptionRequestStatus.html) |  | [optional] |
 {: class="table table-striped"}

--- a/build/src/PureCloudPlatform.Client.V2/Model/TranscriptionTopicTranscriptionMessage.cs
+++ b/build/src/PureCloudPlatform.Client.V2/Model/TranscriptionTopicTranscriptionMessage.cs
@@ -29,7 +29,7 @@ namespace PureCloudPlatform.Client.V2.Model
         /// <param name="TranscriptionStartTimeMs">TranscriptionStartTimeMs.</param>
         /// <param name="Transcripts">Transcripts.</param>
         /// <param name="Status">Status.</param>
-        public TranscriptionTopicTranscriptionMessage(DateTime? EventTime = null, string OrganizationId = null, string ConversationId = null, string CommunicationId = null, int? SessionStartTimeMs = null, int? TranscriptionStartTimeMs = null, List<TranscriptionTopicTranscriptResult> Transcripts = null, TranscriptionTopicTranscriptionRequestStatus Status = null)
+        public TranscriptionTopicTranscriptionMessage(DateTime? EventTime = null, string OrganizationId = null, string ConversationId = null, string CommunicationId = null, long? SessionStartTimeMs = null, long? TranscriptionStartTimeMs = null, List<TranscriptionTopicTranscriptResult> Transcripts = null, TranscriptionTopicTranscriptionRequestStatus Status = null)
         {
             this.EventTime = EventTime;
             this.OrganizationId = OrganizationId;
@@ -80,7 +80,7 @@ namespace PureCloudPlatform.Client.V2.Model
         /// Gets or Sets SessionStartTimeMs
         /// </summary>
         [DataMember(Name="sessionStartTimeMs", EmitDefaultValue=false)]
-        public int? SessionStartTimeMs { get; set; }
+        public long? SessionStartTimeMs { get; set; }
 
 
 
@@ -88,7 +88,7 @@ namespace PureCloudPlatform.Client.V2.Model
         /// Gets or Sets TranscriptionStartTimeMs
         /// </summary>
         [DataMember(Name="transcriptionStartTimeMs", EmitDefaultValue=false)]
-        public int? TranscriptionStartTimeMs { get; set; }
+        public long? TranscriptionStartTimeMs { get; set; }
 
 
 


### PR DESCRIPTION
If you use Notification Handler and you add subscription for event of type "v2.conversations.{id}.transcription", you get an error on line 231 of NotificationHandler.cs when the data payload is being deserialize to the specific type of event. The fields *sessionStartTimeMs* and *transcriptionStartTimeMs* are not int values but long. Here's a actual payload of this kind of event:

```
{

  "TopicName": "v2.conversations.7328f3d5-4ac2-4ec6-a637-df7720b09019.transcription",

  "Version": "2",

  "EventBody": {

    "eventTime": "2024-03-02T14:57:43.61Z",

    "organizationId": "d3ddab4d-c9e6-454b-bc52-34c6ba239682",

    "conversationId": "7328f3d5-4ac2-4ec6-a637-df7720b09019",

    "communicationId": "759dc8e4-97d6-4e9b-bea5-bffdf3791f38",

    "sessionStartTimeMs": 1709391384214,

    "transcriptionStartTimeMs": 1709391384077,

    "status": {

      "status": "SESSION_ENDED",

      "offsetMs": 79280

    }

  },

  "Metadata": {

    "CorrelationId": "26e9b396-8429-4884-898c-84ef0d6c540c"

  }
```
Int value max out at 2147483647.